### PR TITLE
Braces, readme, and printf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # enableIPv6 #
 
+[![License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE)
+
+
 This is a shell script built to search the user's AWS account for VPCs in each region, and enable IPv6 capabilities on each. This tool goes as far as associating an Amazon-provided IPv6 CIDR block for each VPC found, updating all Route Tables in each VPC to include a default route for IPv6 traffic to the IGW, and update Security Groups to include rules to allow IPv6 traffic. The results (successes and failures alike) are saved in the resulting log file, stored in the same directory the script is launched from.
 
 What this script does not do is add subnets with new IPv6 address space (you must do that on your own or modify the code to do so, since I didn't get that far just yet). It does not launch new resources, just modifies existing ones.
 
 Ideally I'd have this script be written using the SDK for a more clean and expandable tool, but this is the current build and should work for most.
-
+- - - -
 # How To Use It #
 
 1. Configure the awscli on your workstation. Ensure you have a Bash shell available in /usr/bin/env. (You likely do.)
@@ -13,12 +16,14 @@ Ideally I'd have this script be written using the SDK for a more clean and expan
 3. Run the src/enableIPv6.sh script. 
 4. When it's done, allocate IPv6 address space for your subnets in those VPCs.
 
+- - - -
 # Known Issues #
 
 As of today's launch[1], this script should only work in us-east-2 (Ohio), but should function when new regions are added.
 
 [1] https://aws.amazon.com/blogs/aws/new-ipv6-support-for-ec2-instances-in-virtual-private-clouds/
 
+- - - -
 # If You Run Into Trouble #
 
 Open an Issue. I made this for my own needs and am offering it as a best-effort sharing of knowledge to the world, and will work on issues in the same best-effort approach.

--- a/src/enableIPv6.sh
+++ b/src/enableIPv6.sh
@@ -23,52 +23,52 @@ for region in "${REGIONLIST[@]}"; do
   # Blank the VPC array for each new region
   VPCLIST=()
 
-  echo "===="
-  echo "Checking ${REGION} for VPC IDs."
+  printf "====\n"
+  printf "Checking ${REGION} for VPC IDs.\n"
 
   for vpcid in `aws ec2 describe-vpcs --output json --region ${REGION} | grep -ohE "\w*vpc-[a-zA-Z0-9]{8}"`; do
     VPCLIST+=("${VPCID}")
-    echo "${REGION}: ${VPCID}"
+    printf "${REGION}: ${VPCID}\n"
   done
 
-  echo ""
+  printf '\n'
 
   for vpcid in "${VPCLIST[@]}"; do
-    echo "[Enabling IPv6 on ${VPCID}]"
+    printf "[Enabling IPv6 on ${VPCID}]\n"
 
-    echo "Associating IPv6 CIDR Block to ${VPCID}."
+    printf "Associating IPv6 CIDR Block to ${VPCID}.\n"
     aws ec2 associate-vpc-cidr-block --output json --region ${REGION} --vpc-id ${VPCID} --amazon-provided-ipv6-cidr-block
 
     TARGETIGW=$(aws ec2 describe-internet-gateways --output json --region ${REGION} | grep -B 10 "${VPCID}" | grep -oh "\w*igw-\w*")
 
     # One IGW per VPC, but many possible Route Tables per VPC.
     for routetable in `aws ec2 describe-route-tables --output json --region ${REGION} | grep -B 1 "${VPCID}" | grep -oh "\w*rtb-\w*"`; do
-      echo "Updating ${ROUTETABLE} with IPv6 default route to ${TARGETIGW}."
+      printf "Updating ${ROUTETABLE} with IPv6 default route to ${TARGETIGW}.\n"
       aws ec2 create-route --output json --region ${REGION} --route-table-id ${ROUTETABLE} --gateway-id ${TARGETIGW} --destination-ipv6-cidr-block "::/0"
     done
 
     # The following updates all Security Groups in the VPC to allow IPv6 traffic outbound. This occurs on every Security Group, so it may not fit everyone's use case. 
     # Disable if you don't want some Security Groups to allow access to the Internet for IPv6 traffic. Generally we do, so it is enabled by default.
     for securitygroup in `aws ec2 describe-security-groups --output json --region ${REGION} | grep -A 3 "${VPCID}" | grep -oh "\w*sg-\w*"`; do
-      echo "Updating ${SECURITYGROUP} to allow IPv6 traffic. $(aws ec2 describe-security-groups --output json --region ${REGION} --group-id "${SECURITYGROUP}" | grep GroupName)"
+      printf "Updating ${SECURITYGROUP} to allow IPv6 traffic. $(aws ec2 describe-security-groups --output json --region ${REGION} --group-id "${SECURITYGROUP}" | grep GroupName)\n"
       aws ec2 authorize-security-group-ingress --output json --region ${REGION} --group-id ${SECURITYGROUP} --ip-permissions '[{"Ipv6Ranges":[{"CidrIpv6":"::/0"}], "IpProtocol":"-1"}]'
     done
 
     # Verify that the VPC got an IPv6 assignment.
     aws ec2 describe-vpcs --output json --region ${REGION} --vpc-id ${VPCID} | grep -A 8 "Ipv6CidrBlockAssociationSet"
 
-    echo "Remember to allocate subnets for each VPC or you won't be using any of your assigned CIDR block."
+    printf "Remember to allocate subnets for each VPC or you won't be using any of your assigned CIDR block.\n"
     # aws ec2 associate-subnet-cidr-block --output json --region ${REGION} --subnet-id ${TARGETSUB} --ipv6-cidr-block <::/64>
     # aws ec2 modify-subnet-attribute --output json --region ${REGION} --subnet ${TARGETSUB} --assign-ipv6-address-on-creation
     # aws ec2 modify-subnet-attribute --output json --region ${REGION} --subnet ${TARGETSUB} --map-public-ip-on-launch
 
-    echo ""
-    echo "----"
-    echo "${REGION}: ${VPCID} is now enabled for IPv6!"
-    echo "----"
+    printf '\n'
+    printf "----\n"
+    printf "${REGION}: ${VPCID} is now enabled for IPv6!\n"
+    printf "----\n"
 
   done
 
-  echo "${REGION} Completed."
-  echo "===="
+  printf "${REGION} Completed.\n"
+  printf "====\n"
 done


### PR DESCRIPTION
I wrapped the majority of your variables in curly braces. I also slightly updated your readme with horizontal rules. I swapped all occurrences of `echo` to `printf` because `printf` is a bash builtin and not a standalone binary. The speed increase is minimal at best, but you are marginally more POSIX compatible so hooray!